### PR TITLE
limoo requires Qt5

### DIFF
--- a/Limoo.pro
+++ b/Limoo.pro
@@ -5,6 +5,7 @@ icon_files.target = $${DESTDIR}/files
 translation_files.source = files/translations
 translation_files.target = $${DESTDIR}/files
 DEPLOYMENTFOLDERS = qml_files translation_files icon_files
+lessThan(QT_MAJOR_VERSION, 5): error("requires Qt 5")
 
 QT += widgets script
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Switch to source directory
 ##### Ubuntu
 
     mkdir build && cd build
-    qmake -r ..
+    qmake -qt=5 -r ..
     make
 
 You can use command below after building to clean build directory on the each step.


### PR DESCRIPTION
my system was picking up Qt4 by default.

qmake did not complain, other then outputting two warnings people could easily ignore.

I am adding a requirement in the project file
and updating the README to invite people to use the -qt=5 flag

cheers,

